### PR TITLE
gh-19: add steps() to iterate over steps

### DIFF
--- a/glass/ext/pkdgrav/__init__.py
+++ b/glass/ext/pkdgrav/__init__.py
@@ -4,13 +4,16 @@ GLASS extension for PKDGRAV simulations.
 
 __all__ = [
     "ClassCosmology",
-    "SimpleCosmology",
     "ParfileError",
+    "SimpleCosmology",
+    "Simulation",
+    "Step",
     "load",
     "read_gowerst",
+    "steps",
 ]
 
 from ._cosmology import ClassCosmology, SimpleCosmology
 from ._gowerst import read_gowerst
 from ._parfile import ParfileError
-from ._pkdgrav import load
+from ._pkdgrav import Simulation, Step, load, steps


### PR DESCRIPTION
Adds a new `glass.ext.pkdgrav.steps()` function to iterate over the metadata of the simulation steps without having to read all of the simulation outputs.

Closes: #19